### PR TITLE
Add/remove vectors to create list and changes for smoother slide.

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { DataSet } from "./types/data";
+import { debounce } from "lodash";
 import type { NextPage } from "next";
 import ImpactVectorDisplay from "~~/components/impact-vector/ImpactVectorDisplay";
 import ImpactVectorGraph from "~~/components/impact-vector/ImpactVectorGraph";
@@ -14,11 +15,8 @@ const Home: NextPage = () => {
   const [impactData, setImpactData] = useState<DataSet[]>([]);
 
   useEffect(() => {
-    // Initialize selected vectors with two vectorWeights
-    setSelectedVectors([
-      { name: "OSO: Total Stars", weight: 50 },
-      { name: "OSO: Total Onchain Users", weight: 100 },
-    ]);
+    // Initialize selected vector
+    setSelectedVectors([{ name: "OSO: Total Onchain Users", weight: 100 }]);
   }, [setSelectedVectors]);
 
   useEffect(() => {
@@ -30,7 +28,9 @@ const Home: NextPage = () => {
         }
 
         // Check if all selected vectors have valid names and weights
-        const isValidSelection = selectedVectors.every(vector => vector.name.trim() !== "" && !isNaN(vector.weight));
+        const isValidSelection = selectedVectors.every(
+          (vector: { name: string; weight: number }) => vector.name.trim() !== "" && !isNaN(vector.weight),
+        );
 
         if (!isValidSelection) {
           return;
@@ -55,14 +55,15 @@ const Home: NextPage = () => {
       }
     };
 
-    fetchData();
+    const debouncedFetchData = debounce(fetchData, 300);
+    debouncedFetchData();
   }, [selectedVectors]);
 
   return (
     <main className="max-w-[1700px] mx-auto w-full flex flex-col gap-2 b-md:flex-row p-2">
       <div className="w-full min-w-[55%]">
         <h2 className="text-center">Impact Calculator 🌱</h2>
-        <div className="flex w-full h-3/5 pb-2">{impactData.length > 0 && <ImpactVectorGraph data={impactData} />}</div>
+        <div className="flex w-full h-1/2 pb-2">{impactData.length > 0 && <ImpactVectorGraph data={impactData} />}</div>
         {/* still a work in progress */}
         <div className="mt-4">
           <ImpactVectorTable />

--- a/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { useGlobalState } from "~~/services/store/store";
 
 interface ImpactVectorCardProps {
   name: string;
@@ -12,12 +13,22 @@ interface ImpactVectorCardProps {
 const ImpactVectorCard = ({ name, description, username }: ImpactVectorCardProps) => {
   //the route is hard coded for now
   const router = useRouter();
+  const { selectedVectors, setSelectedVectors } = useGlobalState();
+
+  const handleAddVector = (vectorName: string) => {
+    // Check if the vector is not already selected
+    if (!selectedVectors.find(vector => vector.name === vectorName)) {
+      const newSelectedVectors = [...selectedVectors, { name: vectorName, weight: 100 }];
+      setSelectedVectors(newSelectedVectors);
+    }
+  };
+
   return (
     <div
       onClick={() => router.push("/impact/1")}
-      className="cursor-pointer rounded-xl text-sm border-[0.2px] border-secondary-text/50 p-4 bg-base-300 flex flex-col justify-between gap-4"
+      className="cursor-pointer rounded-xl text-sm border-[0.2px] border-secondary-text/50 p-4 bg-base-300 flex flex-col justify-between gap-4 my-2"
     >
-      <h2 className="pl-2  m-0 font-bold">{name}</h2>
+      <h2 className="pl-2  m-0 font-bold">{name.split(":")[1]}</h2>
       <div className="flex items-center">
         <div className="max-w-[19.18rem] text-base-content-100   ">
           <p className="m-0 p-0">{description.length > 100 ? description.slice(0, 100) + "..." : description}</p>
@@ -26,6 +37,7 @@ const ImpactVectorCard = ({ name, description, username }: ImpactVectorCardProps
           <button
             onClick={e => {
               e.stopPropagation();
+              handleAddVector(name);
             }}
             className="rounded-xl bg-primary hover:bg-red-600 p-4"
           >

--- a/packages/nextjs/components/impact-vector/ImpactVectorDisplay.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorDisplay.tsx
@@ -1,20 +1,19 @@
 import ImpactVectorCard from "./ImpactVectorCard";
-import impactVectorJson from "~~/public/data/ImpactVectors.json";
+import { impactVectors } from "./ImpactVectors";
 
 const ImpactVectorDisplay = () => {
   return (
     <div
       className="max-h-[700px] overflow-y-auto
-scrollbar-none "
+scrollbar-none pb-60"
     >
       {/* this is hard coded for now */}
-      {impactVectorJson.map((vector, index) => (
+      {impactVectors.map((vector, index) => (
         <ImpactVectorCard
           key={index}
-          name={vector.split(":")[1]}
-          description=" This impact vector measures the growth and activity levels of users within the optimism ecosystem
-             "
-          username="chatgpt"
+          name={vector.name}
+          description={vector.description}
+          username={vector.sourceName}
         />
       ))}
     </div>

--- a/packages/nextjs/components/impact-vector/ImpactVectorTable.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorTable.tsx
@@ -1,5 +1,4 @@
 import ImpactTableHeader from "./table-components/ImpactTableHeader";
-import { debounce } from "lodash";
 import { BsCheck } from "react-icons/bs";
 import { FiTrash2 } from "react-icons/fi";
 import { useGlobalState } from "~~/services/store/store";
@@ -7,15 +6,16 @@ import { useGlobalState } from "~~/services/store/store";
 const ImpactVectorTable = () => {
   const { selectedVectors, setSelectedVectors } = useGlobalState();
 
-  const debouncedSetSelectedVectors = debounce((index: number, newValue: number) => {
+  const handleRangeChange = (index: number, newValue: number) => {
     const updatedSelectedVectors = selectedVectors.map((vector, i) =>
       i === index ? { ...vector, weight: newValue } : vector,
     );
     setSelectedVectors(updatedSelectedVectors);
-  }, 300);
+  };
 
-  const handleRangeChange = (index: number, newValue: number) => {
-    debouncedSetSelectedVectors(index, newValue);
+  const handleRemoveVector = (vectorName: string) => {
+    const updatedSelectedVectors = selectedVectors.filter(vector => vector.name !== vectorName);
+    setSelectedVectors(updatedSelectedVectors);
   };
 
   return (
@@ -34,7 +34,7 @@ const ImpactVectorTable = () => {
               </td>
               <td className="py-2 sm:py-4 whitespace-nowrap text-xs sm:text-sm ">
                 <div className="flex flex-col ">
-                  <span className="font-semibold">{vector.name}</span>
+                  <span className="font-semibold">{vector.name.split(":")[1]}</span>
                 </div>
               </td>
               <td className="px-3 lg:px-6 py-2 sm:py-4 whitespace-nowrap text-sm ">
@@ -54,7 +54,7 @@ const ImpactVectorTable = () => {
                 <div className="grid gap-2 items-center justify-end grid-flow-col">
                   <div className="flex gap-1 sm:gap-3 ">
                     <button className="w-[20px]">
-                      <FiTrash2 size={20} />
+                      <FiTrash2 size={20} onClick={() => handleRemoveVector(vector.name)} />
                     </button>
                   </div>
                 </div>

--- a/packages/nextjs/components/impact-vector/ImpactVectors.ts
+++ b/packages/nextjs/components/impact-vector/ImpactVectors.ts
@@ -1,0 +1,92 @@
+export const impactVectors = [
+  {
+    name: "OSO: # GitHub Repos",
+    description: "Description for GitHub Repos impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Date First Commit",
+    description: "Description for Date First Commit impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Total Stars",
+    description: "Description for Total Stars impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Total Forks",
+    description: "Description for Total Forks impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Total Contributors",
+    description: "Description for Total Contributors impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Contributors Last 6 Months",
+    description: "Description for Contributors Last 6 Months impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Avg Monthly Active Devs Last 6 Months",
+    description: "Description for Avg Monthly Active Devs Last 6 Months impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: # OP Contracts",
+    description: "Description for OP Contracts impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Date First Txn",
+    description: "Description for Date First Txn impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Total Onchain Users",
+    description: "Description for Total Onchain Users impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Onchain Users Last 6 Months",
+    description: "Description for Onchain Users Last 6 Months impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Total Txns",
+    description: "Description for Total Txns impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Total Txn Fees (ETH)",
+    description: "Description for Total Txn Fees (ETH) impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Txn Fees Last 6 Months (ETH)",
+    description: "Description for Txn Fees Last 6 Months (ETH) impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: # NPM Packages",
+    description: "Description for NPM Packages impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Date First Download",
+    description: "Description for Date First Download impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Total Downloads",
+    description: "Description for Total Downloads impact vector.",
+    sourceName: "OSO",
+  },
+  {
+    name: "OSO: Downloads Last 6 Months",
+    description: "Description for Downloads Last 6 Months impact vector.",
+    sourceName: "OSO",
+  },
+];


### PR DESCRIPTION
This PR enables the addition of vectors to the list by clicking the red folder icon. 
The slides are smoother.
Additionally, users can now remove vectors from the list.


## Related Issues

_Closes #{#8}_ : Vectors can be added to the list under the graph by clicking on the folder icon. The graph reflects the added vectors, which can be deleted using the trash icon.
_Closes #{#17}_ : Adding impact vectors triggers a redraw, ensuring the graph reflects the updated vectors and weights.
_Closes #{#16}_ : Vectors are now addable to the list using the folder icon in the sidebar.