### PR TITLE
Hovering over graph displays project image.

### DIFF
--- a/packages/nextjs/components/impact-vector/CustomXAxis.tsx
+++ b/packages/nextjs/components/impact-vector/CustomXAxis.tsx
@@ -1,17 +1,16 @@
 interface CustomXAxisProps {
   x: number;
   y: number;
-  // payload: any;
+  image: any;
+  hovered: string | null;
+  payload: any;
 }
 
-const CustomXAxisTick: React.FC<CustomXAxisProps> = ({
-  x,
-  y,
-  // payload
-}) => {
+const CustomXAxisTick: React.FC<CustomXAxisProps> = ({ x, y, hovered, image, payload }) => {
+  const isHovered = payload && payload.value === hovered;
   return (
     <g transform={`translate(${x},${y})`} style={{ fontSize: 12, fill: "#333" }}>
-      {/* on hover display project image or name */}
+      {isHovered && image && <image href={image} width={45} height={45} />}
     </g>
   );
 };

--- a/packages/nextjs/components/impact-vector/ImpactVectorGraph.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorGraph.tsx
@@ -17,7 +17,7 @@ const transformData = (impactData: DataSet[]): any[] => {
     const transformedItem: any = {
       image: item.metadata["Meta: Project Image"],
       name: item.metadata["Meta: Project Name"],
-      total: Math.floor(item.total),
+      Rank: Math.floor(item.total),
     };
 
     dataKeys.forEach(key => {
@@ -28,14 +28,22 @@ const transformData = (impactData: DataSet[]): any[] => {
   });
 };
 
-// Function to sort array in descending order based on 'total'
+// Function to sort array in descending order based on rank
 const sortByTotalDescending = (dataSetArray: any[]) => {
   return dataSetArray.slice().sort((a, b) => b.total - a.total);
 };
 
 export default function ImpactVectorGraph({ data }: { data: DataSet[] }) {
   const [showVectors, setShowVectors] = useState(false);
+  const [hoveredProject, setHoveredProject] = useState<string | null>(null);
   const transformedData = transformData(sortByTotalDescending(data));
+
+  const handleMouseMove = (e: any) => {
+    const { value } = e;
+    if (hoveredProject !== value) {
+      setHoveredProject(value);
+    }
+  };
 
   return (
     <div className="flex flex-col w-full">
@@ -50,11 +58,37 @@ export default function ImpactVectorGraph({ data }: { data: DataSet[] }) {
             left: 20,
             bottom: 40,
           }}
+          onMouseMove={e => {
+            const { activePayload } = e;
+            if (activePayload && activePayload.length > 0) {
+              const hoveredProjectName = activePayload[0].payload.name;
+              if (hoveredProject !== hoveredProjectName) {
+                setHoveredProject(hoveredProjectName);
+              }
+            } else {
+              setHoveredProject(null);
+            }
+          }}
         >
-          <XAxis dataKey="name" axisLine={false} tickLine={false} tick={<CustomXAxis x={0} y={0} />} interval={0} />
+          <XAxis
+            dataKey="name"
+            onMouseMove={handleMouseMove}
+            axisLine={false}
+            tickLine={false}
+            tick={
+              <CustomXAxis
+                payload
+                image={hoveredProject ? transformedData.find(item => item.name === hoveredProject)?.image : null}
+                hovered={hoveredProject && hoveredProject}
+                x={0}
+                y={0}
+              />
+            }
+            interval={0}
+          />
           <Tooltip />
 
-          <Line type="monotone" dataKey="total" stroke="red" dot={false} strokeWidth={3} />
+          <Line type="monotone" dataKey="Rank" stroke="red" dot={false} strokeWidth={3} />
 
           {showVectors &&
             transformedData[0] &&

--- a/packages/nextjs/next.config.js
+++ b/packages/nextjs/next.config.js
@@ -19,6 +19,9 @@ const nextConfig = {
       fullUrl: true,
     },
   },
+  images: {
+    domains: ['content.optimism.io'],
+  }
 };
 
 module.exports = nextConfig;


### PR DESCRIPTION
This pull request offers a potential solution for maintaining graph cleanliness while displaying all projects, as discussed in issue #27. In this PR, the movement along the line showcases each returned project's image (if available).

![Screenshot 2024-02-16 at 15-20-13 Impact Calculator App](https://github.com/BuidlGuidl/impact-calculator/assets/53488449/4bd44b5b-1ef8-46ed-8a26-11c6b06c6c9e)

Additionally, 'Total' has been relabeled to 'Rank' in the graph component. However, it's important to note that the API still returns 'Total' until the required changes are fully implemented.
