### PR TITLE
Menu spacing

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -70,7 +70,7 @@ const Home: NextPage = () => {
         </div>
       </div>
 
-      <div className="max-h-[100dvh] overflow-hidden b-md:max-w-[34rem] w-full rounded-3xl p-6 border grid gap-6 ">
+      <div className="max-h-[100dvh] overflow-hidden b-md:max-w-[34rem] w-full rounded-3xl p-6 border grid gap-6 mx-auto">
         <div className="rounded-xl grid grid-cols-2 bg-base-300 p-1">
           <button className={` bg-base-100 font-semibold  py-3 text- rounded-xl text-center w-full`}>
             Impact Vectors

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -60,7 +60,7 @@ const Home: NextPage = () => {
   }, [selectedVectors]);
 
   return (
-    <main className="max-w-[1700px] mx-auto w-full flex flex-col gap-6 sm:gap-10 b-md:flex-row py-3">
+    <main className="max-w-[1700px] mx-auto w-full flex flex-col gap-6 sm:gap-10 b-md:flex-row p-3">
       <div className="w-full min-w-[55%]">
         <h2 className="text-center">Impact Calculator 🌱</h2>
         <div className="flex w-full h-1/2 pb-2">{impactData.length > 0 && <ImpactVectorGraph data={impactData} />}</div>

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -60,7 +60,7 @@ const Home: NextPage = () => {
   }, [selectedVectors]);
 
   return (
-    <main className="max-w-[1700px] mx-auto w-full flex flex-col gap-2 b-md:flex-row py-3">
+    <main className="max-w-[1700px] mx-auto w-full flex flex-col gap-6 sm:gap-10 b-md:flex-row py-3">
       <div className="w-full min-w-[55%]">
         <h2 className="text-center">Impact Calculator 🌱</h2>
         <div className="flex w-full h-1/2 pb-2">{impactData.length > 0 && <ImpactVectorGraph data={impactData} />}</div>

--- a/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
@@ -27,7 +27,7 @@ const ImpactVectorCard = ({ name, description, username }: ImpactVectorCardProps
   return (
     <div
       onClick={() => router.push("/impact/1")}
-      className="cursor-pointer rounded-xl text-sm border-[0.2px] border-secondary-text/50 p-4 bg-base-300 flex flex-col justify-between gap-4 my-2"
+      className="mr-1 cursor-pointer rounded-xl text-sm border-[0.2px] border-secondary-text/50 p-4 bg-base-300 flex flex-col justify-between gap-4 my-2"
     >
       <h2 className=" m-0 font-bold"> {trim(name.split(":")[1])}</h2>
       <div className="flex items-center justify-between">

--- a/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
@@ -3,6 +3,7 @@
 import React from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
+import { trim } from "lodash";
 import { useGlobalState } from "~~/services/store/store";
 
 interface ImpactVectorCardProps {
@@ -28,12 +29,12 @@ const ImpactVectorCard = ({ name, description, username }: ImpactVectorCardProps
       onClick={() => router.push("/impact/1")}
       className="cursor-pointer rounded-xl text-sm border-[0.2px] border-secondary-text/50 p-4 bg-base-300 flex flex-col justify-between gap-4 my-2"
     >
-      <h2 className="pl-2  m-0 font-bold">{name.split(":")[1]}</h2>
-      <div className="flex items-center">
-        <div className="w-[70%] text-base-content-100   ">
+      <h2 className=" m-0 font-bold"> {trim(name.split(":")[1])}</h2>
+      <div className="flex items-center justify-between">
+        <div className=" text-base-content-100   ">
           <p className="m-0 p-0">{description.length > 100 ? description.slice(0, 100) + "..." : description}</p>
         </div>
-        <div className=" w-[30%] text-center">
+        <div className="">
           <button
             onClick={e => {
               e.stopPropagation();

--- a/packages/nextjs/components/impact-vector/ImpactVectorDisplay.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorDisplay.tsx
@@ -5,7 +5,7 @@ const ImpactVectorDisplay = () => {
   return (
     <div
       className="max-h-[700px] overflow-y-auto
-scrollbar-none pb-60"
+      scrollbar-w-2 scrollbar scrollbar-thumb-slate-300 scrollbar-thumb-rounded-full pb-6"
     >
       {/* this is hard coded for now */}
       {impactVectors.map((vector, index) => (

--- a/packages/nextjs/components/impact-vector/ImpactVectorTable.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorTable.tsx
@@ -1,6 +1,5 @@
 import { useState } from "react";
 import ImpactTableHeader from "./table-components/ImpactTableHeader";
-import { BsCheck } from "react-icons/bs";
 import { FiTrash2 } from "react-icons/fi";
 import { useGlobalState } from "~~/services/store/store";
 
@@ -51,11 +50,6 @@ const ImpactVectorTable = () => {
         <tbody className="divide-y divide-gray-300 ">
           {sortedVectors.map((vector, index) => (
             <tr key={vector.name}>
-              <td className="px-2 md:px-4 py-2 sm:py-3 ">
-                <div className="flex items-center cursor-pointer w-5 h-5 border border-[#7F56D9] rounded-lg">
-                  <BsCheck size={24} className="text-[#7F56D9]" />
-                </div>
-              </td>
               <td className="py-2 sm:py-4 whitespace-nowrap text-xs sm:text-sm ">
                 <div className="flex flex-col ">
                   <span className="font-semibold">{vector.name.split(":")[1].substring(1)}</span>

--- a/packages/nextjs/components/impact-vector/table-components/ImpactTableHeader.tsx
+++ b/packages/nextjs/components/impact-vector/table-components/ImpactTableHeader.tsx
@@ -19,10 +19,7 @@ const ImpactTableHeader = ({ sortDesc, setSortDesc, sortBy, setSortBy }: Props) 
   return (
     <>
       <tr>
-        <th scope="col" className=" w-8 py-3 px-2 md:px-4 ">
-          <div className="flex items-center h-5"></div>
-        </th>
-        <th scope="col" className=" py-3 w-[20%]  text-start text-xs font-medium  ">
+        <th scope="col" className=" py-3  w-[20%]  text-start text-xs font-medium  ">
           <div className="flex items-center gap-1">
             <span className="cursor-pointer" onClick={getClickHandler("name")}>
               Impact Vector

--- a/packages/nextjs/styles/globals.css
+++ b/packages/nextjs/styles/globals.css
@@ -5,7 +5,7 @@
 
 :root,
 [data-theme] {
-  background: oklch(var(--b2));
+  background: white;
 }
 
 body {


### PR DESCRIPTION
## Description
Moved the “add to ballot” button of an impact vector in the selection menu slightly to the right, with the same distance to the border as the text
Moved the title of an impact vector in selection menu slightly to the left to align with the impact vector description
Replaced blue background w white
Removed tickbox next to impact vectors
Weird cutoff of edges on Impact Vector selection 
#40  #39 #35 #33
_Concise description of proposed changes, We recommend using screenshots and videos for better description
![Screenshot from 2024-02-22 12-08-02](https://github.com/BuidlGuidl/impact-calculator/assets/64108987/b3194653-624f-4814-87c3-f1db785df569)

![Screenshot from 2024-02-22 11-48-18](https://github.com/BuidlGuidl/impact-calculator/assets/64108987/151493af-1089-48cd-bd55-d544f188b889)

## Additional Information

- [ ] I have read the [contributing docs](/scaffold-eth/scaffold-eth-2/blob/main/CONTRIBUTING.md) (if this is your first contribution)
- [ ] This is not a duplicate of any [existing pull request](https://github.com/scaffold-eth/scaffold-eth-2/pulls)

## Related Issues

_Closes #{issue number}_

_Note: If your changes are small and straightforward, you may skip the creation of an issue beforehand and remove this section. However, for medium-to-large changes, it is recommended to have an open issue for discussion and approval prior to submitting a pull request._

Your ENS/address:
