### PR TITLE
Expand graph to full width of page

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -62,7 +62,11 @@ const Home: NextPage = () => {
 
   return (
     <main className={`w-full flex flex-col gap-6 sm:gap-10 p-3 ${!fullGraph && "lg:mb-[22rem]"} relative`}>
-      <div className={`${fullGraph ? "w-full" : "lg:w-[58%]"} duration-500 ease-in-out h-[60vh] transition-all`}>
+      <div
+        className={`${
+          fullGraph ? "w-full" : "lg:w-[50%] xl:w-[58%] 2xl:w-[64%] 3xl:w-[70%]"
+        } duration-500 ease-in-out h-[60vh] transition-all`}
+      >
         <h2 className="text-center">Impact Calculator 🌱</h2>
         <div className="flex w-full h-[60vh]">
           {impactData.length > 0 && (
@@ -72,7 +76,11 @@ const Home: NextPage = () => {
       </div>
 
       <div className="flex flex-col lg:flex-row">
-        <div className={`lg:mx-5 ${fullGraph ? "flex-1" : "lg:w-[58%]"} w-full lg:mt-0 mt-6`}>
+        <div
+          className={`lg:mx-5 ${
+            fullGraph ? "flex-1" : "lg:w-[50%] xl:w-[58%] 2xl:w-[64%] 3xl:w-[70%]"
+          } w-full lg:mt-0 mt-6`}
+        >
           <ImpactVectorTable />
         </div>
         <div

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -64,28 +64,29 @@ const Home: NextPage = () => {
     <main
       className={`w-full flex flex-col gap-6 sm:gap-10 b-md:flex-row p-3 ${!fullGraph && "lg:mb-[22rem]"} relative`}
     >
-      <div className="w-full min-w-[55%]">
+      <div className={`${fullGraph ? "w-full" : "lg:w-[55%]"} duration-400 ease-in-out h-[60vh] transition-all`}>
         <h2 className="text-center">Impact Calculator 🌱</h2>
-        <div className="flex w-full h-1/2">
+        <div className="flex w-full h-[60vh]">
           {impactData.length > 0 && (
             <ImpactVectorGraph data={impactData} fullGraph={fullGraph} setFullGraph={setFullGraph} />
           )}
         </div>
-        {/* still a work in progress */}
+      </div>
+
+      <div className="flex flex-col lg:flex-row">
         <div className="mx-5">
           <ImpactVectorTable />
         </div>
-      </div>
-
-      <div className="max-h-[100dvh] overflow-hidden b-md:max-w-[34rem] w-full rounded-3xl p-6 border grid gap-6 mx-auto">
-        <div className="rounded-xl grid grid-cols-2 bg-base-300 p-1">
-          <button className={` bg-base-100 font-semibold  py-3 text- rounded-xl text-center w-full`}>
-            Impact Vectors
-          </button>
-          <button className={`py-3 text-customGray rounded-xl text-center w-full bg-[#f2f4f9]`}>Lists</button>
+        <div className="max-h-[100dvh] overflow-hidden b-md:max-w-[34rem] w-full rounded-3xl p-6 border grid gap-6 mx-auto">
+          <div className="rounded-xl grid grid-cols-2 bg-base-300 p-1">
+            <button className={` bg-base-100 font-semibold  py-3 text- rounded-xl text-center w-full`}>
+              Impact Vectors
+            </button>
+            <button className={`py-3 text-customGray rounded-xl text-center w-full bg-[#f2f4f9]`}>Lists</button>
+          </div>
+          <SearchBar />
+          <ImpactVectorDisplay />
         </div>
-        <SearchBar />
-        <ImpactVectorDisplay />
       </div>
     </main>
   );

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -61,7 +61,9 @@ const Home: NextPage = () => {
   }, [selectedVectors]);
 
   return (
-    <main className="w-full flex flex-col gap-6 sm:gap-10 b-md:flex-row p-3">
+    <main
+      className={`w-full flex flex-col gap-6 sm:gap-10 b-md:flex-row p-3 ${!fullGraph && "lg:mb-[22rem]"} relative`}
+    >
       <div className="w-full min-w-[55%]">
         <h2 className="text-center">Impact Calculator 🌱</h2>
         <div className="flex w-full h-1/2">

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -13,6 +13,7 @@ import { useGlobalState } from "~~/services/store/store";
 const Home: NextPage = () => {
   const { selectedVectors, setSelectedVectors } = useGlobalState();
   const [impactData, setImpactData] = useState<DataSet[]>([]);
+  const [fullGraph, setFullGraph] = useState<boolean>(false);
 
   useEffect(() => {
     // Initialize selected vector
@@ -63,7 +64,11 @@ const Home: NextPage = () => {
     <main className="w-full flex flex-col gap-6 sm:gap-10 b-md:flex-row p-3">
       <div className="w-full min-w-[55%]">
         <h2 className="text-center">Impact Calculator 🌱</h2>
-        <div className="flex w-full h-1/2">{impactData.length > 0 && <ImpactVectorGraph data={impactData} />}</div>
+        <div className="flex w-full h-1/2">
+          {impactData.length > 0 && (
+            <ImpactVectorGraph data={impactData} fullGraph={fullGraph} setFullGraph={setFullGraph} />
+          )}
+        </div>
         {/* still a work in progress */}
         <div className="mx-5">
           <ImpactVectorTable />

--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -61,10 +61,8 @@ const Home: NextPage = () => {
   }, [selectedVectors]);
 
   return (
-    <main
-      className={`w-full flex flex-col gap-6 sm:gap-10 b-md:flex-row p-3 ${!fullGraph && "lg:mb-[22rem]"} relative`}
-    >
-      <div className={`${fullGraph ? "w-full" : "lg:w-[55%]"} duration-400 ease-in-out h-[60vh] transition-all`}>
+    <main className={`w-full flex flex-col gap-6 sm:gap-10 p-3 ${!fullGraph && "lg:mb-[22rem]"} relative`}>
+      <div className={`${fullGraph ? "w-full" : "lg:w-[58%]"} duration-500 ease-in-out h-[60vh] transition-all`}>
         <h2 className="text-center">Impact Calculator 🌱</h2>
         <div className="flex w-full h-[60vh]">
           {impactData.length > 0 && (
@@ -74,10 +72,14 @@ const Home: NextPage = () => {
       </div>
 
       <div className="flex flex-col lg:flex-row">
-        <div className="mx-5">
+        <div className={`lg:mx-5 ${fullGraph ? "flex-1" : "lg:w-[58%]"} w-full lg:mt-0 mt-6`}>
           <ImpactVectorTable />
         </div>
-        <div className="max-h-[100dvh] overflow-hidden b-md:max-w-[34rem] w-full rounded-3xl p-6 border grid gap-6 mx-auto">
+        <div
+          className={`b-md:w-[34rem] w-full ${
+            fullGraph ? "lg:relative mt-0" : "lg:absolute lg:top-0 lg:right-0"
+          } transition-all overflow-hidden h-auto b-md:max-w-[34rem] rounded-3xl p-6 border grid gap-6 mx-auto duration-1000 ease-in-out`}
+        >
           <div className="rounded-xl grid grid-cols-2 bg-base-300 p-1">
             <button className={` bg-base-100 font-semibold  py-3 text- rounded-xl text-center w-full`}>
               Impact Vectors

--- a/packages/nextjs/components/impact-vector/ImpactVectorGraph.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorGraph.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState } from "react";
+import React, { Dispatch, SetStateAction, useState } from "react";
 import CustomXAxis from "./CustomXAxis";
 import { Area, AreaChart, CartesianGrid, Line, ResponsiveContainer, Tooltip, XAxis, YAxis } from "recharts";
 import { DataSet, ImpactVectors } from "~~/app/types/data";
@@ -29,7 +29,15 @@ const sortByTotalDescending = (dataSetArray: any[]) => {
   return dataSetArray.slice().sort((a, b) => b.opAllocation - a.opAllocation);
 };
 
-export default function ImpactVectorGraph({ data }: { data: DataSet[] }) {
+export default function ImpactVectorGraph({
+  data,
+  fullGraph,
+  setFullGraph,
+}: {
+  data: DataSet[];
+  fullGraph: boolean;
+  setFullGraph: Dispatch<SetStateAction<boolean>>;
+}) {
   const [showVectors, setShowVectors] = useState(false);
   const [isLogarithmic, setIsLogarithmic] = useState(false);
   const [hoveredProject, setHoveredProject] = useState<string | null>(null);
@@ -63,6 +71,22 @@ export default function ImpactVectorGraph({ data }: { data: DataSet[] }) {
           <button onClick={() => setShowVectors(!showVectors)}>{showVectors ? "Hide Vectors" : "Show Vectors"}</button>
           <button className="px-3" onClick={() => setIsLogarithmic(!isLogarithmic)}>
             {isLogarithmic ? "Linear" : "Logarithmic"}
+          </button>
+          <button onClick={() => setFullGraph(!fullGraph)} className="hidden lg:flex">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth={1.5}
+              stroke="currentColor"
+              className="5-4 h-5"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                d="M3.75 3.75v4.5m0-4.5h4.5m-4.5 0L9 9M3.75 20.25v-4.5m0 4.5h4.5m-4.5 0L9 15M20.25 3.75h-4.5m4.5 0v4.5m0-4.5L15 9m5.25 11.25h-4.5m4.5 0v-4.5m0 4.5L15 15"
+              />
+            </svg>
           </button>
         </div>
       )}

--- a/packages/nextjs/tailwind.config.js
+++ b/packages/nextjs/tailwind.config.js
@@ -110,6 +110,7 @@ module.exports = {
       screens: {
         xs: "480px",
         "b-md": "880px",
+        "3xl": "1800px",
       },
     },
   },


### PR DESCRIPTION
Changes:
 - This PR adjusts the layout to allow the graph to fill the entire width of the view.

 - Shifts the vector selection menu downward to maintain proximity to the adjustable vectors table.

 - Places the action button to the right of the existing buttons.

Initial view
![image](https://github.com/BuidlGuidl/impact-calculator/assets/53488449/4b33d52f-1a2e-4be7-a255-1ab94e0a7b17)

Full width
![image](https://github.com/BuidlGuidl/impact-calculator/assets/53488449/73ed9cd9-17dc-49ee-a44c-2293f1fe67b1)

This pull request focuses on addressing issue #54  while simultaneously removing layout modifications proposed in #52 . Unfortunately, the closed PR could not be reopened. This pull request builds upon the changes introduced in PR #53.