### PR TITLE
Limit api calls

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { DataSet } from "./types/data";
+import { DataSet, Vector } from "./types/data";
 import { debounce } from "lodash";
 import type { NextPage } from "next";
 import ImpactVectorDisplay from "~~/components/impact-vector/ImpactVectorDisplay";
@@ -30,7 +30,7 @@ const Home: NextPage = () => {
 
         // Check if all selected vectors have valid names and weights
         const isValidSelection = selectedVectors.every(
-          (vector: { name: string; weight: number }) => vector.name.trim() !== "" && !isNaN(vector.weight),
+          (vector: Vector) => vector.name.trim() !== "" && !isNaN(vector.weight),
         );
 
         if (!isValidSelection) {

--- a/packages/nextjs/app/types/data.ts
+++ b/packages/nextjs/app/types/data.ts
@@ -71,3 +71,8 @@ export interface DataSet {
   data: { [key in keyof ImpactVectors]: { normalized: number; actual: string | number | undefined } };
   metadata: Metadata;
 }
+
+export interface Vector {
+  name: keyof ImpactVectors;
+  weight: number;
+}

--- a/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
@@ -5,10 +5,11 @@ import Image from "next/image";
 import { useRouter } from "next/navigation";
 import { trim } from "lodash";
 import { HiMiniCheckBadge } from "react-icons/hi2";
+import { ImpactVectors } from "~~/app/types/data";
 import { useGlobalState } from "~~/services/store/store";
 
 interface ImpactVectorCardProps {
-  name: string;
+  name: keyof ImpactVectors;
   description: string;
   sourceName: string;
 }
@@ -18,7 +19,7 @@ const ImpactVectorCard = ({ name, description, sourceName }: ImpactVectorCardPro
   const router = useRouter();
   const { selectedVectors, setSelectedVectors } = useGlobalState();
 
-  const handleAddVector = (vectorName: string) => {
+  const handleAddVector = (vectorName: keyof ImpactVectors) => {
     // Check if the vector is not already selected
     if (!selectedVectors.find(vector => vector.name === vectorName)) {
       const newSelectedVectors = [...selectedVectors, { name: vectorName, weight: 100 }];

--- a/packages/nextjs/components/impact-vector/ImpactVectorTable.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorTable.tsx
@@ -1,18 +1,17 @@
 import { useState } from "react";
 import ImpactTableHeader from "./table-components/ImpactTableHeader";
-import { FiTrash2 } from "react-icons/fi";
+import ImpactTableRow from "./table-components/ImpactTableRow";
+import { Vector } from "~~/app/types/data";
 import { useGlobalState } from "~~/services/store/store";
-
-export type HeaderKey = "name" | "weight";
 
 const ImpactVectorTable = () => {
   const { selectedVectors, setSelectedVectors } = useGlobalState();
   const [sortDesc, setSortDesc] = useState(true);
-  const [sortBy, setSortBy] = useState<HeaderKey>();
+  const [sortBy, setSortBy] = useState<keyof Vector>();
 
-  const handleRangeChange = (index: number, newValue: number) => {
+  const updateVectorWeight = (index: number) => (newWeight: number) => {
     const updatedSelectedVectors = selectedVectors.map((vector, i) =>
-      i === index ? { ...vector, weight: newValue } : vector,
+      i === index ? { ...vector, weight: newWeight } : vector,
     );
     setSelectedVectors(updatedSelectedVectors);
 
@@ -20,11 +19,6 @@ const ImpactVectorTable = () => {
       setSortBy(undefined);
       setSortDesc(true);
     }
-  };
-
-  const handleRemoveVector = (vectorName: string) => {
-    const updatedSelectedVectors = selectedVectors.filter(vector => vector.name !== vectorName);
-    setSelectedVectors(updatedSelectedVectors);
   };
 
   const sortedVectors = selectedVectors.sort((a, b) => {
@@ -49,36 +43,7 @@ const ImpactVectorTable = () => {
         </thead>
         <tbody className="divide-y divide-gray-300 ">
           {sortedVectors.map((vector, index) => (
-            <tr key={vector.name}>
-              <td className="py-2 sm:py-4 whitespace-nowrap text-xs sm:text-sm ">
-                <div className="flex flex-col ">
-                  <span className="font-semibold">{vector.name.split(":")[1].substring(1)}</span>
-                  <span className="text-gray-500">{vector.name}</span>
-                </div>
-              </td>
-              <td className="px-3 lg:px-6 py-2 sm:py-4 whitespace-nowrap text-sm ">
-                <div className="flex items-center justify-center gap-2">
-                  <input
-                    type="range"
-                    min={0}
-                    max="100"
-                    value={vector.weight}
-                    className="range range-primary range-xs  w-full bg-[#F9F5FF] h-2"
-                    onChange={e => handleRangeChange(index, parseInt(e.target.value, 10))}
-                  />
-                  <span>{vector.weight}</span>
-                </div>
-              </td>
-              <td className="pr-2 lg:pr-6 py-2 sm:py-4 whitespace-nowrap ">
-                <div className="grid gap-2 items-center justify-end grid-flow-col">
-                  <div className="flex gap-1 sm:gap-3 ">
-                    <button className="w-[20px]">
-                      <FiTrash2 size={20} onClick={() => handleRemoveVector(vector.name)} />
-                    </button>
-                  </div>
-                </div>
-              </td>
-            </tr>
+            <ImpactTableRow key={vector.name} vector={vector} updateWeight={updateVectorWeight(index)} />
           ))}
         </tbody>
       </table>

--- a/packages/nextjs/components/impact-vector/ImpactVectors.ts
+++ b/packages/nextjs/components/impact-vector/ImpactVectors.ts
@@ -1,4 +1,10 @@
-export const impactVectors = [
+import { ImpactVectors } from "~~/app/types/data";
+
+export const impactVectors: {
+  name: keyof ImpactVectors;
+  description: string;
+  sourceName: string;
+}[] = [
   {
     name: "OSO: Total Stars",
     description:

--- a/packages/nextjs/components/impact-vector/table-components/ImpactTableHeader.tsx
+++ b/packages/nextjs/components/impact-vector/table-components/ImpactTableHeader.tsx
@@ -1,17 +1,17 @@
 import React from "react";
-import { HeaderKey } from "../ImpactVectorTable";
 import { IoArrowDownSharp } from "react-icons/io5";
 import { IoArrowUpSharp } from "react-icons/io5";
+import { Vector } from "~~/app/types/data";
 
 interface Props {
   sortBy?: string;
   sortDesc: boolean;
-  setSortBy: (newSortBy?: HeaderKey) => void;
+  setSortBy: (newSortBy?: keyof Vector) => void;
   setSortDesc: (newSortDesc: boolean) => void;
 }
 
 const ImpactTableHeader = ({ sortDesc, setSortDesc, sortBy, setSortBy }: Props) => {
-  const getClickHandler = (headerKey: HeaderKey) => () => {
+  const getClickHandler = (headerKey: keyof Vector) => () => {
     if (sortBy !== headerKey) setSortBy(headerKey);
     else setSortDesc(!sortDesc);
   };

--- a/packages/nextjs/components/impact-vector/table-components/ImpactTableRow.tsx
+++ b/packages/nextjs/components/impact-vector/table-components/ImpactTableRow.tsx
@@ -1,66 +1,60 @@
 "use client";
 
-import { useState } from "react";
-import { BsCheck } from "react-icons/bs";
-import { FiArrowDown, FiArrowUp, FiEdit2, FiTrash2 } from "react-icons/fi";
+import { useEffect, useState } from "react";
+import { FiTrash2 } from "react-icons/fi";
+import { Vector } from "~~/app/types/data";
+import { useGlobalState } from "~~/services/store/store";
 
-const ImpactTableRow = () => {
-  const [percentageRenge, setPercentageRenge] = useState("40");
-  // this will be changed to the actual data from the API and tanstack table will be used
-  const change = -4;
-  const isChecked = true;
+interface Props {
+  vector: Vector;
+  updateWeight: (newWeight: number) => void;
+}
+
+const ImpactTableRow = ({ vector, updateWeight }: Props) => {
+  const { selectedVectors, setSelectedVectors } = useGlobalState();
+  const [weight, setWeight] = useState<number>(vector.weight);
+
+  useEffect(() => {
+    setWeight(vector.weight);
+  }, [vector]);
+
+  const handleRemoveVector = () => {
+    const updatedSelectedVectors = selectedVectors.filter(existingVector => existingVector.name !== vector.name);
+    setSelectedVectors(updatedSelectedVectors);
+  };
 
   return (
-    <>
-      <td className="px-2 md:px-4 py-2 sm:py-3 ">
-        <div className="flex items-center cursor-pointer w-5 h-5 border   border-[#7F56D9] rounded-lg">
-          {isChecked && <BsCheck size={24} className="text-[#7F56D9]" />}
+    <tr key={vector.name}>
+      <td className="py-2 sm:py-4 whitespace-nowrap text-xs sm:text-sm ">
+        <div className="flex flex-col ">
+          <span className="font-semibold">{vector.name.split(":")[1].substring(1)}</span>
+          <span className="text-gray-500">{vector.name}</span>
         </div>
       </td>
-
-      <td className="  py-2 sm:py-4 whitespace-nowrap text-xs sm:text-sm  ">
-        <div className="flex flex-col  ">
-          <span className="font-semibold">Ecosystem Users</span>
-          <span>vectorname</span>
-        </div>
-      </td>
-      <td className="  px-3 lg:px-6  py-2 sm:py-4 whitespace-nowrap text-sm ">
-        <div className="flex items-center justify-between gap-2">
-          {/* <progress className="progress custom__progress  max-w-[90%] w-full" value={40} max={100}></progress> */}
+      <td className="px-3 lg:px-6 py-2 sm:py-4 whitespace-nowrap text-sm ">
+        <div className="flex items-center justify-center gap-2">
           <input
             type="range"
-            onChange={e => setPercentageRenge(e.target.value)}
             min={0}
             max="100"
-            value={percentageRenge}
-            className="range range-error range-xs max-w-[90%] w-full bg-gray-200"
+            value={weight}
+            className="range range-primary range-xs  w-full bg-[#F9F5FF] h-2"
+            onChange={e => setWeight(parseInt(e.target.value, 10))}
+            onMouseUp={() => updateWeight(weight)}
           />
-          <span className="">{percentageRenge}%</span>
+          <span>{weight}</span>
         </div>
       </td>
-      <td className=" pr-2 lg:pr-6  py-2 sm:py-4  whitespace-nowrap ">
-        <div className="  grid gap-2 items-center justify-between grid-flow-col">
-          <div className=" ">
-            <p
-              className={`px-1 py-[2px] lg:px-2 lg:py-1 rounded-2xl gap-1 text-xs flex items-center font-medium ${
-                change >= 0 ? "text-green-700 bg-green-100" : "text-red-700 bg-red-100"
-              }`}
-            >
-              {change >= 0 ? <FiArrowUp /> : <FiArrowDown />}
-              {Math.abs(change)}%
-            </p>
-          </div>
+      <td className="pr-2 lg:pr-6 py-2 sm:py-4 whitespace-nowrap ">
+        <div className="grid gap-2 items-center justify-end grid-flow-col">
           <div className="flex gap-1 sm:gap-3 ">
-            <button className="   w-[20px]">
-              <FiTrash2 size={20} />
-            </button>
-            <button className="">
-              <FiEdit2 size={20} />
+            <button className="w-[20px]">
+              <FiTrash2 size={20} onClick={handleRemoveVector} />
             </button>
           </div>
         </div>
       </td>
-    </>
+    </tr>
   );
 };
 

--- a/packages/nextjs/services/store/store.ts
+++ b/packages/nextjs/services/store/store.ts
@@ -1,4 +1,5 @@
 import { create } from "zustand";
+import { Vector } from "~~/app/types/data";
 import scaffoldConfig from "~~/scaffold.config";
 import { ChainWithAttributes } from "~~/utils/scaffold-eth";
 
@@ -12,8 +13,8 @@ import { ChainWithAttributes } from "~~/utils/scaffold-eth";
  */
 
 type GlobalState = {
-  selectedVectors: { name: string; weight: number }[];
-  setSelectedVectors: (newSelectedVectors: { name: string; weight: number }[]) => void;
+  selectedVectors: Vector[];
+  setSelectedVectors: (newSelectedVectors: Vector[]) => void;
   nativeCurrencyPrice: number;
   setNativeCurrencyPrice: (newNativeCurrencyPriceState: number) => void;
   targetNetwork: ChainWithAttributes;
@@ -22,8 +23,7 @@ type GlobalState = {
 
 export const useGlobalState = create<GlobalState>(set => ({
   selectedVectors: [],
-  setSelectedVectors: (newSelectedVectors: { name: string; weight: number }[]) =>
-    set(() => ({ selectedVectors: newSelectedVectors })),
+  setSelectedVectors: (newSelectedVectors: Vector[]) => set(() => ({ selectedVectors: newSelectedVectors })),
   nativeCurrencyPrice: 0,
   setNativeCurrencyPrice: (newValue: number): void => set(() => ({ nativeCurrencyPrice: newValue })),
   targetNetwork: scaffoldConfig.targetNetworks[0],


### PR DESCRIPTION
## Description
Makes it so that we only hit our `/impact` API when the user releases the slider, rather than every time the slider value changes.

### Additional Details
- Moves `impactData` and `setImpactData` into global state

### Related Issues
Closes #60 


https://github.com/BuidlGuidl/impact-calculator/assets/22231097/f9099a5f-69e2-4ba0-b154-9a229e4f534d

