### PR TITLE
Feat/save list

### DIFF
--- a/packages/nextjs/app/types/data.ts
+++ b/packages/nextjs/app/types/data.ts
@@ -1,3 +1,5 @@
+import { Address } from "viem";
+
 export interface RetroPGF3Results extends ImpactVectors, Metadata {
   Project_ID: string;
   "Result: # Ballots": number;
@@ -77,4 +79,11 @@ export interface Vector {
 export interface SelectedVector {
   name: keyof ImpactVectors;
   weight: number;
+}
+
+export interface VectorList {
+  creator: Address;
+  title: string;
+  description: string;
+  vectors: SelectedVector[];
 }

--- a/packages/nextjs/components/Header.tsx
+++ b/packages/nextjs/components/Header.tsx
@@ -1,12 +1,15 @@
 "use client";
 
 import Link from "next/link";
-import { FaucetButton, RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
+import { SaveList } from "./impact-vector/SaveList";
+import { useAccount } from "wagmi";
+import { RainbowKitCustomConnectButton } from "~~/components/scaffold-eth";
 
 /**
  * Site header
  */
 export const Header = () => {
+  const { isConnected } = useAccount();
   return (
     <div className="sticky lg:static top-0 navbar bg-base-100 min-h-0 flex-shrink-0 z-20 px-0 sm:px-2">
       <div className="md:navbar-end hidden md:flex text-right items-center lg:w-1/2">
@@ -15,8 +18,8 @@ export const Header = () => {
         </Link>
       </div>
       <div className="navbar-end flex-grow mr-4">
+        {isConnected && <SaveList />}
         <RainbowKitCustomConnectButton />
-        <FaucetButton />
       </div>
     </div>
   );

--- a/packages/nextjs/components/impact-vector/SaveIcon.tsx
+++ b/packages/nextjs/components/impact-vector/SaveIcon.tsx
@@ -1,0 +1,16 @@
+export const SaveIcon = () => (
+  <svg
+    xmlns="http://www.w2.org/2000/svg"
+    fill="none"
+    viewBox="-1 0 24 24"
+    stroke-width="0.5"
+    stroke="currentColor"
+    className="h-7 w-6"
+  >
+    <path
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      d="M2 3v18h18V6l-3-3H3ZM7.5 3v6h9V3M6 21v-9h12v9M14.25 5.25v1.5"
+    />
+  </svg>
+);

--- a/packages/nextjs/components/impact-vector/SaveList.tsx
+++ b/packages/nextjs/components/impact-vector/SaveList.tsx
@@ -1,0 +1,117 @@
+import { ChangeEvent, MouseEvent, useRef, useState } from "react";
+import { SaveIcon } from "./SaveIcon";
+import { useAccount } from "wagmi";
+import { VectorList } from "~~/app/types/data";
+import { useGlobalState } from "~~/services/store/store";
+import { notification } from "~~/utils/scaffold-eth";
+
+export const SaveList = () => {
+  const [title, setTitle] = useState("");
+  const [description, setDescription] = useState("");
+  const modalRef = useRef<HTMLDialogElement>(null);
+  const { selectedVectors } = useGlobalState();
+  const [isSaving, setIsSaving] = useState(false);
+  const { address } = useAccount();
+
+  const openModal = () => {
+    modalRef.current?.showModal();
+  };
+  const closeModal = () => {
+    modalRef.current?.close();
+  };
+
+  const handleChangeTitle = (e: ChangeEvent<HTMLInputElement>) => {
+    setTitle(e.target.value);
+  };
+  const handleChangeDescription = (e: ChangeEvent<HTMLTextAreaElement>) => {
+    setDescription(e.target.value);
+  };
+  const handleSave = async (e: MouseEvent<HTMLButtonElement>) => {
+    e.preventDefault();
+    setIsSaving(true);
+    const body: VectorList = {
+      creator: address as string,
+      title,
+      description,
+      vectors: selectedVectors,
+    };
+
+    const res = await fetch("/api/lists", {
+      method: "POST",
+      body: JSON.stringify(body),
+      headers: {
+        "Content-Type": "application/json",
+      },
+    });
+    setIsSaving(false);
+    if (res.ok) {
+      notification.success("List saved.");
+      setTitle("");
+      setDescription("");
+    } else {
+      notification.error("List not saved. Please try again.");
+    }
+    closeModal();
+  };
+  const handleClose = () => {
+    setTitle("");
+    setDescription("");
+    closeModal();
+  };
+  const readyToSave = title.length > 0;
+
+  return (
+    <>
+      <dialog ref={modalRef} className="modal">
+        <div className="modal-box">
+          <h3 className="font-bold text-lg">Save List</h3>
+          <p className="py-4">
+            Save your selected Impact Vectors and weights so that you can reference this combination in the future.
+          </p>
+          <div className="modal-action">
+            <form method="dialog" className="w-full">
+              <button onClick={handleClose} className="btn btn-sm btn-circle btn-ghost absolute right-2 top-2">
+                ✕
+              </button>
+              <label className="form-control w-full">
+                <div className="label">
+                  <span className="label-text">Title</span>
+                </div>
+                <input
+                  disabled={isSaving}
+                  value={title}
+                  onChange={handleChangeTitle}
+                  type="text"
+                  placeholder="Github Activity"
+                  className="input input-bordered w-full input-sm"
+                />
+              </label>
+              <label className="form-control w-full">
+                <div className="label">
+                  <span className="label-text">Description</span>
+                </div>
+                <textarea
+                  disabled={isSaving}
+                  value={description}
+                  onChange={handleChangeDescription}
+                  placeholder="Projects ranked only by Github stats, prioritizing recent growth in contributors"
+                  className="textarea textarea-bordered textarea-md"
+                />
+              </label>
+              <div className="flex justify-end mt-4">
+                <button onClick={handleSave} disabled={!readyToSave || isSaving} className="btn btn-primary">
+                  {isSaving ? <span className="loading loading-spinner loading-sm"></span> : "Save"}
+                </button>
+              </div>
+            </form>
+          </div>
+        </div>
+      </dialog>
+
+      <button onClick={openModal} className="btn btn-sm mr-2">
+        <SaveIcon />
+        Save List
+      </button>
+    </>
+  );
+};

--- a/packages/nextjs/pages/api/lists/index.ts
+++ b/packages/nextjs/pages/api/lists/index.ts
@@ -1,0 +1,24 @@
+import type { NextApiRequest, NextApiResponse } from "next";
+import { getVectorLists, insertVectorList } from "~~/utils/impactCalculator/data";
+
+export default async function handler(req: NextApiRequest, res: NextApiResponse) {
+  if (req.method === "POST") {
+    try {
+      await insertVectorList(req.body);
+      return res.status(201).json(req.body);
+    } catch (err) {
+      console.log("Error inserting a vector list into db:", err);
+      res.status(500).json({ message: "Internal Server Error" });
+    }
+  }
+  if (req.method === "GET") {
+    try {
+      const vectorLists = await getVectorLists();
+      return res.status(200).json(vectorLists);
+    } catch (err) {
+      console.log("Error retrieving vector lists from db:", err);
+      res.status(500).json({ message: "Internal Server Error" });
+    }
+  }
+  return res.status(403).json({ message: "Method not allowed." });
+}

--- a/packages/nextjs/utils/impactCalculator/data.ts
+++ b/packages/nextjs/utils/impactCalculator/data.ts
@@ -1,4 +1,4 @@
-import { Vector } from "~~/app/types/data";
+import { Vector, VectorList } from "~~/app/types/data";
 import clientPromise from "~~/services/db/mongodb";
 
 export const getVectors = async () => {
@@ -6,4 +6,18 @@ export const getVectors = async () => {
   const db = client.db("impact_calculator");
   const vectors = await db.collection<Vector>("impactVectors").find({}).toArray();
   return vectors;
+};
+
+export const insertVectorList = async (newList: VectorList) => {
+  const client = await clientPromise;
+  const db = client.db("impact_calculator");
+  const collection = db.collection<VectorList>("vectorLists");
+  await collection.insertOne(newList);
+};
+
+export const getVectorLists = async () => {
+  const client = await clientPromise;
+  const db = client.db("impact_calculator");
+  const lists = await db.collection<VectorList>("vectorLists").find({}).toArray();
+  return lists;
 };

--- a/packages/nextjs/utils/scaffold-eth/notification.tsx
+++ b/packages/nextjs/utils/scaffold-eth/notification.tsx
@@ -31,7 +31,7 @@ const ENUM_STATUSES = {
 };
 
 const DEFAULT_DURATION = 3000;
-const DEFAULT_POSITION: ToastPosition = "top-center";
+const DEFAULT_POSITION: ToastPosition = "bottom-left";
 
 /**
  * Custom Notification


### PR DESCRIPTION
## Description
Adds the ability for users to save their current combination of selected vectors and their weights as a list.

[Screencast from 2024-04-02 08-41-47.webm](https://github.com/BuidlGuidl/impact-calculator/assets/22231097/022ae0c1-da3e-46f6-aba3-402b7d57a428)


## Additional Questions
- Now that we're exposing an API route to create data, do y'all think we should restrict access a bit more to prevent any potential spam?
- Also might be a good idea to bring in some kind of data validation to make sure all our db records stay consistent. What do y'all think? @escottalexander do you think [mongoDB schemas](https://www.mongodb.com/docs/atlas/app-services/schemas/) would be a good way to do that?

## Related Issues
Closes #73 


