### PR TITLE
Remove "OSO:" prefix from vector names

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -17,7 +17,7 @@ const Home: NextPage = () => {
 
   useEffect(() => {
     // Initialize selected vector
-    setSelectedVectors([{ name: "OSO: Total Onchain Users", weight: 100 }]);
+    setSelectedVectors([{ name: "Total Onchain Users", weight: 100 }]);
   }, [setSelectedVectors]);
 
   useEffect(() => {

--- a/packages/nextjs/app/types/data.ts
+++ b/packages/nextjs/app/types/data.ts
@@ -34,24 +34,24 @@ export interface RetroPGF3Results extends ImpactVectors, Metadata {
 }
 
 export interface ImpactVectors {
-  "OSO: # GitHub Repos"?: number;
-  "OSO: Date First Commit": string;
-  "OSO: Total Stars"?: number;
-  "OSO: Total Forks"?: number;
-  "OSO: Total Contributors"?: number;
-  "OSO: Contributors Last 6 Months"?: number;
-  "OSO: Avg Monthly Active Devs Last 6 Months": number;
-  "OSO: # OP Contracts"?: number;
-  "OSO: Date First Txn": string;
-  "OSO: Total Onchain Users"?: number;
-  "OSO: Onchain Users Last 6 Months"?: number;
-  "OSO: Total Txns"?: number;
-  "OSO: Total Txn Fees (ETH)": number;
-  "OSO: Txn Fees Last 6 Months (ETH)": number;
-  "OSO: # NPM Packages"?: number;
-  "OSO: Date First Download": string;
-  "OSO: Total Downloads"?: number;
-  "OSO: Downloads Last 6 Months"?: number;
+  "# GitHub Repos"?: number;
+  "Date First Commit": string;
+  "Total Stars"?: number;
+  "Total Forks"?: number;
+  "Total Contributors"?: number;
+  "Contributors Last 6 Months"?: number;
+  "Avg Monthly Active Devs Last 6 Months": number;
+  "# OP Contracts"?: number;
+  "Date First Txn": string;
+  "Total Onchain Users"?: number;
+  "Onchain Users Last 6 Months"?: number;
+  "Total Txns"?: number;
+  "Total Txn Fees (ETH)": number;
+  "Txn Fees Last 6 Months (ETH)": number;
+  "# NPM Packages"?: number;
+  "Date First Download": string;
+  "Total Downloads"?: number;
+  "Downloads Last 6 Months"?: number;
 }
 
 export interface Metadata {

--- a/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
@@ -3,7 +3,6 @@
 import React, { useEffect, useState } from "react";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { trim } from "lodash";
 import { HiMiniCheckBadge } from "react-icons/hi2";
 import { ImpactVectors, Vector } from "~~/app/types/data";
 import { useGlobalState } from "~~/services/store/store";
@@ -31,7 +30,7 @@ const ImpactVectorCard = ({ name, description, sourceName }: Vector) => {
       onClick={() => router.push("/impact/1")}
       className="mr-1 cursor-pointer rounded-xl text-sm border-[0.2px] border-secondary-text/50 p-4 bg-base-300 flex flex-col justify-between gap-4 my-2"
     >
-      <h2 className=" m-0 font-bold"> {trim(name.split(":")[1])}</h2>
+      <h2 className=" m-0 font-bold"> {name}</h2>
       <div className="flex items-center justify-between">
         <div className=" text-base-content-100 max-w-sm pr-4">
           <p className="m-0 p-0">{description.length > 100 ? description.slice(0, 100) + "..." : description}</p>

--- a/packages/nextjs/components/impact-vector/ImpactVectorGraph.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorGraph.tsx
@@ -13,24 +13,24 @@ const logScale = scaleLog();
 const NON_VECTOR_KEYS = ["image", "name", "profile", "opAllocation"];
 
 const COLOR_CLASS_BY_VECTOR: { [key in keyof ImpactVectors]: string } = {
-  "OSO: # GitHub Repos": "text-[#ff0000]",
-  "OSO: Date First Commit": "text-[#00ff00]",
-  "OSO: Total Stars": "text-[#0000ff]",
-  "OSO: Total Forks": "text-[#ffff00]",
-  "OSO: Total Contributors": "text-[#ff00ff]",
-  "OSO: Contributors Last 6 Months": "text-[#00ffff]",
-  "OSO: Avg Monthly Active Devs Last 6 Months": "text-[#ff8000]",
-  "OSO: # OP Contracts": "text-[#8000ff]",
-  "OSO: Date First Txn": "text-[#00ff80]",
-  "OSO: Total Onchain Users": "text-[#ff0080]",
-  "OSO: Onchain Users Last 6 Months": "text-[#80ff00]",
-  "OSO: Total Txns": "text-[#0080ff]",
-  "OSO: Total Txn Fees (ETH)": "text-[#ff0080]",
-  "OSO: Txn Fees Last 6 Months (ETH)": "text-[#ff80ff]",
-  "OSO: # NPM Packages": "text-[#80ff80]",
-  "OSO: Date First Download": "text-[#8080ff]",
-  "OSO: Total Downloads": "text-[#ffff80]",
-  "OSO: Downloads Last 6 Months": "text-[#80ffff]",
+  "# GitHub Repos": "text-[#ff0000]",
+  "Date First Commit": "text-[#00ff00]",
+  "Total Stars": "text-[#0000ff]",
+  "Total Forks": "text-[#ffff00]",
+  "Total Contributors": "text-[#ff00ff]",
+  "Contributors Last 6 Months": "text-[#00ffff]",
+  "Avg Monthly Active Devs Last 6 Months": "text-[#ff8000]",
+  "# OP Contracts": "text-[#8000ff]",
+  "Date First Txn": "text-[#00ff80]",
+  "Total Onchain Users": "text-[#ff0080]",
+  "Onchain Users Last 6 Months": "text-[#80ff00]",
+  "Total Txns": "text-[#0080ff]",
+  "Total Txn Fees (ETH)": "text-[#ff0080]",
+  "Txn Fees Last 6 Months (ETH)": "text-[#ff80ff]",
+  "# NPM Packages": "text-[#80ff80]",
+  "Date First Download": "text-[#8080ff]",
+  "Total Downloads": "text-[#ffff80]",
+  "Downloads Last 6 Months": "text-[#80ffff]",
 };
 const shouldRenderAsVector = (key: string) =>
   !key.includes("_actual") && !key.includes("_normalized") && !NON_VECTOR_KEYS.includes(key);
@@ -182,7 +182,7 @@ export default function ImpactVectorGraph({
                             ? Math.floor(parseFloat(value)) || "none"
                             : value || "none";
                         }
-                        const label = key.replace(/^OSO:/, "").replace("_actual", "");
+                        const label = key.replace("_actual", "");
                         return (
                           <p key={key}>
                             <span className={COLOR_CLASS_BY_VECTOR[key.replace("_actual", "") as keyof ImpactVectors]}>

--- a/packages/nextjs/components/impact-vector/ImpactVectors.ts
+++ b/packages/nextjs/components/impact-vector/ImpactVectors.ts
@@ -2,7 +2,7 @@ import { Vector } from "~~/app/types/data";
 
 export const impactVectors: Vector[] = [
   {
-    name: "OSO: Total Stars",
+    name: "Total Stars",
     description:
       "Reflects the overall popularity and community interest in the project based on the total number of stars it has received.",
     sourceName: "OSO",
@@ -10,7 +10,7 @@ export const impactVectors: Vector[] = [
     fieldName: "stars",
   },
   {
-    name: "OSO: Total Forks",
+    name: "Total Forks",
     description:
       "Indicates the number of times the project has been forked, highlighting its adaptability and potential for community-driven development.",
     sourceName: "OSO",
@@ -18,7 +18,7 @@ export const impactVectors: Vector[] = [
     fieldName: "forks",
   },
   {
-    name: "OSO: Contributors Last 6 Months",
+    name: "Contributors Last 6 Months",
     description:
       "Measures the project's recent contributor activity, providing insights into the current engagement and collaborative nature of the development team.",
     sourceName: "OSO",
@@ -26,7 +26,7 @@ export const impactVectors: Vector[] = [
     fieldName: "contributors_6_months",
   },
   {
-    name: "OSO: Avg Monthly Active Devs Last 6 Months",
+    name: "Avg Monthly Active Devs Last 6 Months",
     description:
       "Represents the average number of developers actively contributing to the project on a monthly basis over the past six months. This metric indicates sustained developer interest and contributions, offering insights into the project's ongoing development dynamics.",
     sourceName: "OSO",
@@ -34,7 +34,7 @@ export const impactVectors: Vector[] = [
     fieldName: "avg_active_devs_6_months",
   },
   {
-    name: "OSO: Total Onchain Users",
+    name: "Total Onchain Users",
     description:
       "Quantifies the total number of unique addresses that have transacted with the project's smart contract or group of contracts, reflecting the overall user base and adoption on the blockchain.",
     sourceName: "OSO",
@@ -42,7 +42,7 @@ export const impactVectors: Vector[] = [
     fieldName: "total_users",
   },
   {
-    name: "OSO: Onchain Users Last 6 Months",
+    name: "Onchain Users Last 6 Months",
     description:
       "Tracks the onchain user growth over the last six months, offering a dynamic perspective on the project's increasing user base.",
     sourceName: "OSO",
@@ -50,7 +50,7 @@ export const impactVectors: Vector[] = [
     fieldName: "users_6_months",
   },
   {
-    name: "OSO: Total Txns",
+    name: "Total Txns",
     description:
       "Illustrates how frequently a project's smart contract or a collection of contracts has been utilized over a specific timeframe. This impact vector provides a quantitative measure of user engagement and the project's overall activity on the blockchain.",
     sourceName: "OSO",
@@ -58,7 +58,7 @@ export const impactVectors: Vector[] = [
     fieldName: "total_txns",
   },
   {
-    name: "OSO: Total Txn Fees (ETH)",
+    name: "Total Txn Fees (ETH)",
     description:
       "Represents the cumulative sum of gas fees contributed to the network by a project's contract or group of contracts within a defined time period. This impact vector not only reflects the economic aspect of the project but also indicates the resources consumed during transactions. Higher total fees suggest increased network participation and resource usage, contributing to the project's impact within the blockchain ecosystem.",
     sourceName: "OSO",
@@ -66,7 +66,7 @@ export const impactVectors: Vector[] = [
     fieldName: "total_l2_gas",
   },
   {
-    name: "OSO: Txn Fees Last 6 Months (ETH)",
+    name: "Txn Fees Last 6 Months (ETH)",
     description:
       "Captures the total transaction fees paid in Ether (ETH) associated with the project's contracts within the last six months. This impact vector highlights recent economic activity and transactional trends, providing valuable insights into the project's financial dynamics.",
     sourceName: "OSO",
@@ -75,7 +75,7 @@ export const impactVectors: Vector[] = [
   },
   // Adding these are in the OSO teams current sprint, hopefully can add them back soon.
   // {
-  //   name: "OSO: Date First Download",
+  //   name: "Date First Download",
   //   description:
   //     "Marks the date when the project was first downloaded, offering a historical context on its initial adoption.",
   //   sourceName: "OSO",
@@ -83,7 +83,7 @@ export const impactVectors: Vector[] = [
   //   fieldName: "",
   // },
   // {
-  //   name: "OSO: Total Downloads",
+  //   name: "Total Downloads",
   //   description:
   //     "Quantifies the overall number of downloads, showcasing the project's reach and popularity among users.",
   //   sourceName: "OSO",
@@ -91,7 +91,7 @@ export const impactVectors: Vector[] = [
   //   fieldName: "",
   // },
   // {
-  //   name: "OSO: Downloads Last 6 Months",
+  //   name: "Downloads Last 6 Months",
   //   description:
   //     "Shows the number of downloads the project has received within the last six months, providing insight into recent trends in user interest and adoption.",
   //   sourceName: "OSO",

--- a/packages/nextjs/components/impact-vector/table-components/ImpactTableRow.tsx
+++ b/packages/nextjs/components/impact-vector/table-components/ImpactTableRow.tsx
@@ -27,7 +27,7 @@ const ImpactTableRow = ({ vector, updateWeight }: Props) => {
     <tr key={vector.name}>
       <td className="py-2 sm:py-4 whitespace-nowrap text-xs sm:text-sm ">
         <div className="flex flex-col ">
-          <span className="font-semibold">{vector.name.split(":")[1].substring(1)}</span>
+          <span className="font-semibold">{vector.name}</span>
           <span className="text-gray-500">{vector.name}</span>
         </div>
       </td>


### PR DESCRIPTION
## Description
The "OSO:" that begins the name of every vector is longer needed, as we're getting all of our data from [OSO](https://www.opensource.observer/).


## Additional Information
- We'll still need to clear the DB before this PR will work correctly on staging. @escottalexander can you share the mongodb credentials and I'll remove the vectors?
- To verify that this works locally, just delete the `impactVectors` collection from the db you're using before running `yarn start`

## Related Issues
Closes #71 

