### PR TITLE
Individual impact vector view

### DIFF
--- a/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
@@ -1,18 +1,35 @@
 "use client";
 
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useRef, useState } from "react";
 import Image from "next/image";
-import { useRouter } from "next/navigation";
 import { trim } from "lodash";
 import { HiMiniCheckBadge } from "react-icons/hi2";
 import { ImpactVectors, Vector } from "~~/app/types/data";
 import { useGlobalState } from "~~/services/store/store";
 
 const ImpactVectorCard = ({ name, description, sourceName }: Vector) => {
-  //the route is hard coded for now
+  const modalRef = useRef<HTMLDialogElement>(null);
   const [isSelected, setIsSelected] = useState(false);
-  const router = useRouter();
   const { selectedVectors, setSelectedVectors } = useGlobalState();
+
+  // modal for vector info
+  const openModal = () => {
+    modalRef.current?.showModal();
+  };
+  const closeModal = () => {
+    modalRef.current?.close();
+  };
+
+  const handleClose = () => {
+    closeModal();
+  };
+
+  // Use the enter or escape key to close modal
+  const handleKeyDown = (e: React.KeyboardEvent<HTMLDialogElement>) => {
+    if (e.key === "Escape" || e.key === "Enter") {
+      closeModal();
+    }
+  };
 
   const handleAddVector = (vectorName: keyof ImpactVectors) => {
     // Check if the vector is not already selected
@@ -28,7 +45,7 @@ const ImpactVectorCard = ({ name, description, sourceName }: Vector) => {
 
   return (
     <div
-      onClick={() => router.push("/impact/1")}
+      onClick={openModal}
       className="mr-1 cursor-pointer rounded-xl text-sm border-[0.2px] border-secondary-text/50 p-4 bg-base-300 flex flex-col justify-between gap-4 my-2"
     >
       <h2 className=" m-0 font-bold"> {trim(name.split(":")[1])}</h2>
@@ -62,6 +79,28 @@ const ImpactVectorCard = ({ name, description, sourceName }: Vector) => {
         )}
       </div>
       <p className=" text-base-content-100  m-0">@{sourceName}</p>
+
+      <>
+        <dialog ref={modalRef} onKeyDown={handleKeyDown} className="modal">
+          <div className="modal-box">
+            <h3 className="font-bold text-lg">{name}</h3>
+            <p className="py-2 text-base">{description}</p>
+            <div className="modal-action">
+              <form method="dialog" className="w-full">
+                <button
+                  onClick={handleClose}
+                  className="btn btn-sm btn-circle focus:border-none btn-ghost absolute right-2 top-2"
+                >
+                  ✕
+                </button>
+                <button onClick={closeModal} className="btn btn-primary flex justify-center mx-auto font-light text-lg">
+                  Close
+                </button>
+              </form>
+            </div>
+          </div>
+        </dialog>
+      </>
     </div>
   );
 };

--- a/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
@@ -88,7 +88,7 @@ const ImpactVectorCard = ({ name, description, sourceName }: Vector) => {
               <form method="dialog" className="w-full">
                 <button
                   onClick={handleClose}
-                  className="btn btn-sm btn-circle focus:border-none btn-ghost absolute right-2 top-2"
+                  className="btn btn-sm btn-circle outline-none btn-ghost absolute right-2 top-2"
                 >
                   ✕
                 </button>


### PR DESCRIPTION
## Description

Modified the behaviour of clicking on the impact vector card so that clicking opens a small dialog instead of switching to a new view.

 Used the current dummy data from the database. This ensures that the dialog will reflect those changes when real descriptions are added centrally.

Added functionality so that hitting the "Enter" or "Esc" key will exit the dialog.

The OSO: in the screenshot is because my local db is still seeded with the old data.
![image](https://github.com/BuidlGuidl/impact-calculator/assets/53488449/986185b4-44f7-4d35-908c-46035abf7108)


## Related Issues

Closes #78 