### PR TITLE
filter step 0.1

### DIFF
--- a/packages/nextjs/app/page.tsx
+++ b/packages/nextjs/app/page.tsx
@@ -93,7 +93,7 @@ const Home: NextPage = () => {
             </button>
             <button className={`py-3 text-customGray rounded-xl text-center w-full bg-[#f2f4f9]`}>Lists</button>
           </div>
-          <SearchBar />
+          <SearchBar placeholder="Search Impact Vectors" />
           <ImpactVectorDisplay />
         </div>
       </div>

--- a/packages/nextjs/components/impact-vector/FilterModal.tsx
+++ b/packages/nextjs/components/impact-vector/FilterModal.tsx
@@ -1,0 +1,55 @@
+import { useRef } from "react";
+import { SearchBar } from "./SearchBar";
+import { FunnelIcon } from "@heroicons/react/24/outline";
+
+const FilterModal = () => {
+  const modalRef = useRef<HTMLDialogElement>(null);
+
+  const openModal = () => {
+    modalRef.current?.showModal();
+  };
+  const closeModal = () => {
+    modalRef.current?.close();
+  };
+
+  const handleKeyDown: React.KeyboardEventHandler<HTMLDivElement> = e => {
+    if (e.key === "Escape") {
+      closeModal();
+    }
+  };
+
+  const handleOutsideClick: React.MouseEventHandler<HTMLDialogElement> = e => {
+    if (e.target === modalRef.current) {
+      closeModal();
+    }
+  };
+
+  return (
+    <>
+      <div onKeyDown={handleKeyDown} className="lg:mr-5 flex justify-end">
+        <button
+          onClick={openModal}
+          className="btn items-center btn-sm rounded-md border-opacity-20 outline-none font-light border-stone-500"
+        >
+          <span className="flex-row flex items-center whitespace-nowrap justify-center gap-x-1 text-sm">
+            <FunnelIcon className="w-5 h-4" />
+            Set filter
+          </span>
+          <span className="badge badge-xs rounded-[0.3rem] bg-slate-500 text-xs text-white p-1 py-2 h-[0.01rem]">
+            0
+          </span>
+        </button>
+      </div>
+
+      <dialog role="dialog" ref={modalRef} className="modal" onClick={handleOutsideClick}>
+        <div className="modal-box min-h-[300px] relative">
+          <SearchBar placeholder="Search filters or presets" />
+
+          <div className="modal-action"></div>
+        </div>
+      </dialog>
+    </>
+  );
+};
+
+export default FilterModal;

--- a/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorCard.tsx
@@ -80,7 +80,7 @@ const ImpactVectorCard = ({ name, description, sourceName }: Vector) => {
       <p className=" text-base-content-100  m-0">@{sourceName}</p>
 
       <>
-        <dialog ref={modalRef} onKeyDown={handleKeyDown} className="modal">
+        <dialog role="dialog" ref={modalRef} onKeyDown={handleKeyDown} className="modal">
           <div className="modal-box">
             <h3 className="font-bold text-lg">{name}</h3>
             <p className="py-2 text-base">{description}</p>

--- a/packages/nextjs/components/impact-vector/ImpactVectorTable.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorTable.tsx
@@ -1,14 +1,10 @@
-import { useRef, useState } from "react";
-import { SearchBar } from "./SearchBar";
+import { useState } from "react";
 import ImpactTableHeader from "./table-components/ImpactTableHeader";
 import ImpactTableRow from "./table-components/ImpactTableRow";
-import { FiSearch } from "react-icons/fi";
-import { FunnelIcon } from "@heroicons/react/24/outline";
 import { SelectedVector } from "~~/app/types/data";
 import { useGlobalState } from "~~/services/store/store";
 
 const ImpactVectorTable = () => {
-  const modalRef = useRef<HTMLDialogElement>(null);
   const { selectedVectors, setSelectedVectors } = useGlobalState();
   const [sortDesc, setSortDesc] = useState(true);
   const [sortBy, setSortBy] = useState<keyof SelectedVector>();
@@ -39,31 +35,8 @@ const ImpactVectorTable = () => {
     return 0;
   });
 
-  // modal for vector info
-  const openModal = () => {
-    modalRef.current?.showModal();
-  };
-  const closeModal = () => {
-    modalRef.current?.close();
-  };
-
-  const handleClose = () => {
-    closeModal();
-  };
-
   return (
     <>
-      <div className="flex justify-end">
-        <button
-          onClick={openModal}
-          className="btn items-center btn-sm rounded-md border-opacity-20 border-stone-500 py-1"
-        >
-          <span className="flex-row flex items-center whitespace-nowrap gap-1">
-            <FunnelIcon className="w-5 h-5" />
-            Set filter
-          </span>
-        </button>
-      </div>
       <table className="min-w-full divide-y divide-gray-300 ">
         <thead className="">
           <ImpactTableHeader sortDesc={sortDesc} setSortDesc={setSortDesc} sortBy={sortBy} setSortBy={setSortBy} />
@@ -74,30 +47,6 @@ const ImpactVectorTable = () => {
           ))}
         </tbody>
       </table>
-
-      {/* modal */}
-      <>
-        <dialog ref={modalRef} className="modal">
-          <div className="modal-box min-h-[300px] relative">
-            <p className="whitespace-nowrap flex gap-4 text-sm opacity-60 top-0 absolute left-3 items-center">
-              <FiSearch className="w-5 h-5" />
-              Press &apos;/&apos; to search filters and &apos;@&apos; to search presets
-            </p>
-
-            <div className="modal-action">
-              <form method="dialog" className="w-full">
-                <button
-                  onClick={handleClose}
-                  className="btn btn-sm btn-circle outline-none btn-ghost absolute right-2 top-2"
-                >
-                  ✕
-                </button>
-                <SearchBar placeholder="Search filters or presets" />
-              </form>
-            </div>
-          </div>
-        </dialog>
-      </>
     </>
   );
 };

--- a/packages/nextjs/components/impact-vector/ImpactVectorTable.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorTable.tsx
@@ -1,10 +1,14 @@
-import { useState } from "react";
+import { useRef, useState } from "react";
+import { SearchBar } from "./SearchBar";
 import ImpactTableHeader from "./table-components/ImpactTableHeader";
 import ImpactTableRow from "./table-components/ImpactTableRow";
+import { FiSearch } from "react-icons/fi";
+import { FunnelIcon } from "@heroicons/react/24/outline";
 import { SelectedVector } from "~~/app/types/data";
 import { useGlobalState } from "~~/services/store/store";
 
 const ImpactVectorTable = () => {
+  const modalRef = useRef<HTMLDialogElement>(null);
   const { selectedVectors, setSelectedVectors } = useGlobalState();
   const [sortDesc, setSortDesc] = useState(true);
   const [sortBy, setSortBy] = useState<keyof SelectedVector>();
@@ -35,8 +39,31 @@ const ImpactVectorTable = () => {
     return 0;
   });
 
+  // modal for vector info
+  const openModal = () => {
+    modalRef.current?.showModal();
+  };
+  const closeModal = () => {
+    modalRef.current?.close();
+  };
+
+  const handleClose = () => {
+    closeModal();
+  };
+
   return (
     <>
+      <div className="flex justify-end">
+        <button
+          onClick={openModal}
+          className="btn items-center btn-sm rounded-md border-opacity-20 border-stone-500 py-1"
+        >
+          <span className="flex-row flex items-center whitespace-nowrap gap-1">
+            <FunnelIcon className="w-5 h-5" />
+            Set filter
+          </span>
+        </button>
+      </div>
       <table className="min-w-full divide-y divide-gray-300 ">
         <thead className="">
           <ImpactTableHeader sortDesc={sortDesc} setSortDesc={setSortDesc} sortBy={sortBy} setSortBy={setSortBy} />
@@ -47,6 +74,30 @@ const ImpactVectorTable = () => {
           ))}
         </tbody>
       </table>
+
+      {/* modal */}
+      <>
+        <dialog ref={modalRef} className="modal">
+          <div className="modal-box min-h-[300px] relative">
+            <p className="whitespace-nowrap flex gap-4 text-sm opacity-60 top-0 absolute left-3 items-center">
+              <FiSearch className="w-5 h-5" />
+              Press &apos;/&apos; to search filters and &apos;@&apos; to search presets
+            </p>
+
+            <div className="modal-action">
+              <form method="dialog" className="w-full">
+                <button
+                  onClick={handleClose}
+                  className="btn btn-sm btn-circle outline-none btn-ghost absolute right-2 top-2"
+                >
+                  ✕
+                </button>
+                <SearchBar placeholder="Search filters or presets" />
+              </form>
+            </div>
+          </div>
+        </dialog>
+      </>
     </>
   );
 };

--- a/packages/nextjs/components/impact-vector/SearchBar.tsx
+++ b/packages/nextjs/components/impact-vector/SearchBar.tsx
@@ -1,13 +1,13 @@
 import React from "react";
 
-export const SearchBar = () => {
+export const SearchBar = ({ placeholder }: { placeholder: string }) => {
   return (
     <div className="relative">
       <input
         className="input input-info input-bordered bg-secondary focus:outline-none border pl-10 border-neutral hover:border-gray-400  rounded-xl w-full p-3 text-neutral-500 leading-tight  "
         id="username"
         type="text"
-        placeholder="Search Impact Vectors"
+        placeholder={placeholder}
       />
 
       <div className="absolute left-0 inset-y-0 flex items-center">

--- a/packages/nextjs/components/impact-vector/table-components/ImpactTableHeader.tsx
+++ b/packages/nextjs/components/impact-vector/table-components/ImpactTableHeader.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+import FilterModal from "../FilterModal";
 import { IoArrowDownSharp } from "react-icons/io5";
 import { IoArrowUpSharp } from "react-icons/io5";
 import { SelectedVector } from "~~/app/types/data";
@@ -19,7 +20,7 @@ const ImpactTableHeader = ({ sortDesc, setSortDesc, sortBy, setSortBy }: Props) 
   return (
     <>
       <tr>
-        <th scope="col" className=" pb-3  w-[20%]  text-start text-xs font-medium  ">
+        <th scope="col" className="pb-1 w-[20%] text-start text-xs font-medium">
           <div className="flex items-center gap-1">
             <span className="cursor-pointer" onClick={getClickHandler("name")}>
               Impact Vector
@@ -28,7 +29,7 @@ const ImpactTableHeader = ({ sortDesc, setSortDesc, sortBy, setSortBy }: Props) 
           </div>
         </th>
 
-        <th scope="col" className=" px-3 lg:px-6  pb-3 w-[75%]  text-start text-xs font-medium  ">
+        <th scope="col" className="px-3 lg:px-6 pb-1 w-[75%] text-start text-xs font-medium">
           <div className="flex items-center gap-1">
             <span className="cursor-pointer" onClick={getClickHandler("weight")}>
               Weight
@@ -36,7 +37,9 @@ const ImpactTableHeader = ({ sortDesc, setSortDesc, sortBy, setSortBy }: Props) 
             {sortBy === "weight" && (sortDesc ? <IoArrowDownSharp /> : <IoArrowUpSharp />)}
           </div>
         </th>
-        <th scope="col" className="pl-6 py-3 w-[10%]  text-start  text-xs font-medium  "></th>
+        <th className="pb-1">
+          <FilterModal />
+        </th>
       </tr>
     </>
   );

--- a/packages/nextjs/components/impact-vector/table-components/ImpactTableRow.tsx
+++ b/packages/nextjs/components/impact-vector/table-components/ImpactTableRow.tsx
@@ -32,7 +32,7 @@ const ImpactTableRow = ({ vector, updateWeight }: Props) => {
         </div>
       </td>
       <td className="px-3 lg:px-6 py-2 sm:py-4 whitespace-nowrap text-sm ">
-        <div className="flex items-center justify-center gap-2">
+        <div className="flex items-center -mr-20 justify-center gap-2">
           <input
             type="range"
             min={0}


### PR DESCRIPTION
## Description

Changes Made:

Added a button on the main view.

When the button is clicked, it opens a modal.
![image](https://github.com/BuidlGuidl/impact-calculator/assets/53488449/731554bb-8235-4d5c-8a8f-73ced420d4fb)

    
 ##   Additional Info

I wasn't entirely sure if the keycap beside the "Set Filters" text on the button was intended to be the keycap emoji or if it was meant to be dynamic. Therefore, I omitted it for now. If it should be the keycap zero emoji, please let me know, and I'll gladly add it.

I've started working on getting an input field at the top of the modal (assumed we might use a reusable input search, so the search is the same as the one waiting to be used for searching vectors but refactored it to take a "placeholder" arg. if it doesn't make sense I can make a dedicated search component for filters and presets)

## Related issue
#79 