### PR TITLE
Select the top projects instead of the bottom projects

### DIFF
--- a/packages/nextjs/components/impact-vector/ImpactVectorGraph.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorGraph.tsx
@@ -123,7 +123,7 @@ export default function ImpactVectorGraph({
         <ComposedChart
           width={500}
           height={300}
-          data={transformedData.slice(-projectsShown, -1)}
+          data={transformedData.slice(-projectsShown)}
           margin={{
             top: 5,
             right: 30,

--- a/packages/nextjs/components/impact-vector/ImpactVectorGraph.tsx
+++ b/packages/nextjs/components/impact-vector/ImpactVectorGraph.tsx
@@ -123,7 +123,7 @@ export default function ImpactVectorGraph({
         <ComposedChart
           width={500}
           height={300}
-          data={[...transformedData].splice(0, projectsShown)}
+          data={transformedData.slice(-projectsShown, -1)}
           margin={{
             top: 5,
             right: 30,


### PR DESCRIPTION
This fixes the zoom feature so that it defaults to the top projects instead of the lowest projects.
![image](https://github.com/BuidlGuidl/impact-calculator/assets/22101475/728da4a3-9a61-48ab-926e-e050e0c2cd0a)
